### PR TITLE
Add new bug trimming phase

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,6 +1,7 @@
 {
-  "openPhases" : ["phaseBugReporting", "phaseTeamResponse", "phaseTesterResponse", "phaseModeration"],
+  "openPhases" : ["phaseBugReporting", "phaseBugTrimming", "phaseTeamResponse", "phaseTesterResponse", "phaseModeration"],
   "phaseBugReporting": "bugreporting",
+  "phaseBugTrimming": "bugreporting",
   "phaseTeamResponse": "pe-results",
   "phaseTesterResponse": "bugreporting",
   "phaseModeration": "pe-evaluation"


### PR DESCRIPTION
### Summary:
Fixes #4 

### Changes Made:
Added new phase `phaseBugTrimming` in settings.json. The new phase will point to the same repo that is used for bug reporting.

### Proposed Commit Message:
```
Add new phaseBugTrimming to settings.json

CATcher is implementing a new phase and
public_data has to update it phases to support
the new phase.

The relevant issue can be found in CATcher repo
issue #1301.
```
